### PR TITLE
Fix for deprecation of artifact actions in v3 [2/2]

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,4 +32,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v1
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## 概要

- 以下エラー対応のため、`actions/deploy-pages` をv1からv4に変更。
- https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/

## 詳細

- 変更した内容を具体的に書く

## チェック項目

- [ ] Dev環境で動作確認をした
- [ ] 複雑なコードにはコメントを記載してある

## コメント
