### PR TITLE
PR用のaction runnnerをEOLしたubuntu-20.04からubuntu-latestに変更

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -2,9 +2,9 @@ name: ci-for-pull-request
 on:
   pull_request:
 
-# concurrency:
-#   cancel-in-progress: true
-#   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+concurrency:
+  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
 
 jobs:
   build:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/src/content/members/enrolled.ts
+++ b/src/content/members/enrolled.ts
@@ -50,8 +50,8 @@ export const enrolledMembers: EnrolledMembersType[] = [
         image: "/member/takeda.webp",
       },
       {
-        name: "SHOGO YAGETA",
-        altName: "SHOGO YAGETA",
+        name: "SHOGO YAGETA!",
+        altName: "SHOGO YAGETA!",
         image: "/member/yageta.webp",
       },
       { name: "YU SHUKYO", altName: "YU SHUKYO" },

--- a/src/content/members/enrolled.ts
+++ b/src/content/members/enrolled.ts
@@ -50,8 +50,8 @@ export const enrolledMembers: EnrolledMembersType[] = [
         image: "/member/takeda.webp",
       },
       {
-        name: "SHOGO YAGETA!",
-        altName: "SHOGO YAGETA!",
+        name: "SHOGO YAGETA",
+        altName: "SHOGO YAGETA",
         image: "/member/yageta.webp",
       },
       { name: "YU SHUKYO", altName: "YU SHUKYO" },


### PR DESCRIPTION
## 概要

- PR用のaction runnnerをEOLしたubuntu-20.04からubuntu-latestに変更

## チェック項目

- このPRのActionが正しく動作していることを確認

## コメント

未来の真鍋研メンバーへ

次何か問題が起きたら、試しにubuntu24系で動くか確認してみて。
ダメそうならnodeのバージョンを上げて
