### PR TITLE
業績にジャーナル(EC)を追加

### DIFF
--- a/src/pages/result.mdx
+++ b/src/pages/result.mdx
@@ -10,10 +10,14 @@ title: 研究成果
 
 ## 2026年度
 
+### ジャーナル
+
+- Ryoto Nohara, Hironori Ishikawa, Hiroyuki Manabe, "[HMK+Pointing: Mixed-character text entry on HMDs via a multimodal head-mounted keyboard and pointing](https://doi.org/10.1016/j.entcom.2026.101136)", Entertainment Computing, vol. 58, pp. 101-136, 2026.
+
 ### 国際会議
 
-- Shinichi Ishihara, Ryusuke Miyazaki, Shio Miyafuji, Hiroyuki Manabe, “[DIM3: Display as an Interface Medium to Three-dimension with Swept a Bending-Plastic-Plate](https://doi.org/10.1145/3772363.3799151),” In Extended Abstracts of the 2026 CHI Conference on Human Factors in Computing Systems (CHI EA ’26), No.829, pp. 1-5, 2026. (demo paper)
-- Tsuoi Morioka, Hiroyuki Manabe, “[MetAct: Fabrication Technique for Interactive 3D Objects Using Low-Melting-Point Metal Extrusion on Standard FDM 3D Printers](https://doi.org/10.1145/3772363.3799153),” In Extended Abstracts of the 2026 CHI Conference on Human Factors in Computing Systems (CHI EA ’26), No.852, pp. 1-5, 2026. (demo paper)
+- Shinichi Ishihara, Ryusuke Miyazaki, Shio Miyafuji, Hiroyuki Manabe, “[DIM3: Display as an Interface Medium to Three-dimension with Swept a Bending-Plastic-Plate](https://doi.org/10.1145/3772363.3799151),” In Extended Abstracts of the 2026 CHI Conference on Human Factors in Computing Systems (CHI EA '26), No.829, pp. 1-5, 2026. (demo paper)
+- Tsuoi Morioka, Hiroyuki Manabe, “[MetAct: Fabrication Technique for Interactive 3D Objects Using Low-Melting-Point Metal Extrusion on Standard FDM 3D Printers](https://doi.org/10.1145/3772363.3799153),” In Extended Abstracts of the 2026 CHI Conference on Human Factors in Computing Systems (CHI EA '26), No.852, pp. 1-5, 2026. (demo paper)
 
 ---
 
@@ -69,8 +73,8 @@ title: 研究成果
 
 ### 国際会議
 
-- Tatsuya Kawasaki, Hiroyuki Manabe, “[LensTouch: Touch Input on Lens Surfaces of Smart Glasses](https://doi.org/10.1145/3586182.3615792),” Adjunct Proc. Symp. User Interface Software and Technology (UIST ’23), Article No. 56, pp. 1-3, 2023. (demo paper)
-- Ryoto Nohara, Hironori Ishikawa, Hiroyuki Manabe, “[Positions of Wearable Keyboard in VR Environment](https://doi.org/10.1145/3607822.3618026),” Proc. 2023 ACM Symposium on Spatial User Interaction (SUI ’23), Article No. 38, pp. 1-3, 2023. (poster paper) SUI 2023 <span style="color: red;">**Best Poster Honorable Mention Award**</span>
+- Tatsuya Kawasaki, Hiroyuki Manabe, “[LensTouch: Touch Input on Lens Surfaces of Smart Glasses](https://doi.org/10.1145/3586182.3615792),” Adjunct Proc. Symp. User Interface Software and Technology (UIST '23), Article No. 56, pp. 1-3, 2023. (demo paper)
+- Ryoto Nohara, Hironori Ishikawa, Hiroyuki Manabe, “[Positions of Wearable Keyboard in VR Environment](https://doi.org/10.1145/3607822.3618026),” Proc. 2023 ACM Symposium on Spatial User Interaction (SUI '23), Article No. 38, pp. 1-3, 2023. (poster paper) SUI 2023 <span style="color: red;">**Best Poster Honorable Mention Award**</span>
 - Kouga Abe, Hironori Ishikawa, Hiroyuki Manabe, “[A Hybrid Method Using Gaze and Controller for Targeting Tiny Targets in VR While Lying down](https://doi.org/10.1007/978-3-031-36004-6_19),” HCI International 2023 Posters, pp. 139-146, 2023.
 - Eldiaz Salman Koeshandika, Hironori Ishikawa, Hiroyuki Manabe, “[Effects of Different Postures on User Experience in Virtual Reality](https://doi.org/10.1007/978-3-031-36004-6_30),” HCI International 2023 Posters, pp. 219-226, 2023.
 - Akari Kanei, Hiroyuki Manabe, “[Exergame to Promote Exercise Outside Physical Education Classes During a Pandemic](https://doi.org/10.1007/978-3-031-35998-9_36),” HCI International 2023 Posters, pp. 259-266, 2023.
@@ -95,8 +99,8 @@ title: 研究成果
 ### 国際会議
 
 - Tantiworachot Chaiyapat, Manabe Hiroyuki, “[Summer Skybox: A Device Representing the Sky for Personalized Day Cycle](https://doi.org/10.1145/3532525.3532532),” _13th Augmented Human International Conference_ (AH2022), pp. 1-4, 2022.(Short paper) <span style="color: red;">**Best Short Paper award**</span>
-- Suzuki Tomohito, Imai Yuhei, ManabeHiroyuki, “[A bonding technique for electric circuit prototyping using conductive transfer foil and soldering iron](https://doi.org/10.1145/3526114.3558670),” Adjunct Proc. Symp. User Interface Software and Technology (UIST ’22 Adjunct), pp. 1-3, 2022, (demo paper)
-- Takumi Suzuki, Hiroyuki Manabe, “[Estimation of Brush Type Passive Stylus Angles Using Capacitive Image](https://doi.org/10.1145/3569009.3573112),” Proc. International Conference on Tangible, Embedded and Embodied Interaction (TEI ’23), Article No. 42, pp. 1-6, 2023. (poster paper)
+- Suzuki Tomohito, Imai Yuhei, ManabeHiroyuki, “[A bonding technique for electric circuit prototyping using conductive transfer foil and soldering iron](https://doi.org/10.1145/3526114.3558670),” Adjunct Proc. Symp. User Interface Software and Technology (UIST '22 Adjunct), pp. 1-3, 2022, (demo paper)
+- Takumi Suzuki, Hiroyuki Manabe, “[Estimation of Brush Type Passive Stylus Angles Using Capacitive Image](https://doi.org/10.1145/3569009.3573112),” Proc. International Conference on Tangible, Embedded and Embodied Interaction (TEI '23), Article No. 42, pp. 1-6, 2023. (poster paper)
 
 ### 国内会議
 
@@ -118,8 +122,8 @@ title: 研究成果
 
 ### 国際会議
 
-- Yuhei Imai, Hiroyuki Manabe, “[Single-sided Multi-layer Electric Circuit by Hot Stamping with 3D Printer](https://doi.org/10.1145/3474349.3480200),” Adjunct Proc. Symp. User Interface Software and Technology (UIST ’21), pp. 126-128, 2021. (demo paper)
-- Wahyu Hutama, Hikari Harashima, Hironori Ishikawa, Hiroyuki Manabe, “[HMK: Head-Mounted-Keyboard for Text Inputin Virtual or Augmented Reality](https://doi.org/10.1145/3474349.3480195),” Adjunct Proc. Symp. User Interface Software and Technology (UIST ’21), pp. 115-117, 2021. (demo paper)
+- Yuhei Imai, Hiroyuki Manabe, “[Single-sided Multi-layer Electric Circuit by Hot Stamping with 3D Printer](https://doi.org/10.1145/3474349.3480200),” Adjunct Proc. Symp. User Interface Software and Technology (UIST '21), pp. 126-128, 2021. (demo paper)
+- Wahyu Hutama, Hikari Harashima, Hironori Ishikawa, Hiroyuki Manabe, “[HMK: Head-Mounted-Keyboard for Text Inputin Virtual or Augmented Reality](https://doi.org/10.1145/3474349.3480195),” Adjunct Proc. Symp. User Interface Software and Technology (UIST '21), pp. 115-117, 2021. (demo paper)
 
 ### 国内会議
 
@@ -140,7 +144,7 @@ title: 研究成果
 
 ### 国際会議
 
-- Hiroyuki Manabe, Yuki Iwai, “[Backhand Display: A Wearable Device for the Back of the Hand](https://doi.org/10.1145/3380867.3426200),” Companion Proc. Conf. on Interactive Surfaces and Spaces (ISS ’20), pp. 41-45, 2020. (poster)
+- Hiroyuki Manabe, Yuki Iwai, “[Backhand Display: A Wearable Device for the Back of the Hand](https://doi.org/10.1145/3380867.3426200),” Companion Proc. Conf. on Interactive Surfaces and Spaces (ISS '20), pp. 41-45, 2020. (poster)
 
 ### 国内会議
 
@@ -155,10 +159,10 @@ title: 研究成果
 
 ### 国際会議
 
-- Mengting Huang, Kazuyuki Fujita, Kazuki Takashima, Taichi Tsuchida, Hiroyuki Manabe, Yoshifumi Kitamura, “[ShearSheet: Low-Cost Shear Force Input with Elastic Feedback for Augmenting Touch Interaction](https://doi.org/10.1145/3343055.3359717),” Proc. Int. Conf. Interactive Surfaces and Spaces (ISS ’19), pp. 77-87, 2019. (full paper)ISS 2019 <span style="color: red;">**Best Demo Award**</span>
-- Yuhei Imai, Kunihiro Kato, Norihisa Segawa, Hiroyuki Manabe, “[Hot Stamping of Electric Circuits by 3D Printer](https://doi.org/10.1145/3332167.3356895),” Adjunct Proc. Symp. User Interface Software and Technology (UIST ’19), pp. 128-130, 2019. (demo paper)
-- Norihisa Segawa, Kunihiro Kato, Hiroyuki Manabe, “[Rapid Prototyping of Paper Electronics Using a Metal Leaf and Laser Printer](https://doi.org/10.1145/3332167.3356885),” Adjunct Proc. Symp. User Interface Software and Technology (UIST ’19), pp. 99-101, 2019. (demo paper)
-- Yoshinari Takegawa, Kohei Matsumura, Hiroyuki Manabe, “[PokeRepo Go++: One-man Live Reporting System with a Commentator Function](https://doi.org/10.1145/3317697.3325126),” Proc. International Conference on Interactive Experiences for Television and Online Video (TVX ’19), pp. 230-238, 2019. (poster)
+- Mengting Huang, Kazuyuki Fujita, Kazuki Takashima, Taichi Tsuchida, Hiroyuki Manabe, Yoshifumi Kitamura, “[ShearSheet: Low-Cost Shear Force Input with Elastic Feedback for Augmenting Touch Interaction](https://doi.org/10.1145/3343055.3359717),” Proc. Int. Conf. Interactive Surfaces and Spaces (ISS '19), pp. 77-87, 2019. (full paper)ISS 2019 <span style="color: red;">**Best Demo Award**</span>
+- Yuhei Imai, Kunihiro Kato, Norihisa Segawa, Hiroyuki Manabe, “[Hot Stamping of Electric Circuits by 3D Printer](https://doi.org/10.1145/3332167.3356895),” Adjunct Proc. Symp. User Interface Software and Technology (UIST '19), pp. 128-130, 2019. (demo paper)
+- Norihisa Segawa, Kunihiro Kato, Hiroyuki Manabe, “[Rapid Prototyping of Paper Electronics Using a Metal Leaf and Laser Printer](https://doi.org/10.1145/3332167.3356885),” Adjunct Proc. Symp. User Interface Software and Technology (UIST '19), pp. 99-101, 2019. (demo paper)
+- Yoshinari Takegawa, Kohei Matsumura, Hiroyuki Manabe, “[PokeRepo Go++: One-man Live Reporting System with a Commentator Function](https://doi.org/10.1145/3317697.3325126),” Proc. International Conference on Interactive Experiences for Television and Online Video (TVX '19), pp. 230-238, 2019. (poster)
 
 ### 国内会議
 


### PR DESCRIPTION
## 概要

- 業績としてジャーナル(EC)を追加

## 詳細

- 業績にジャーナルを追加
- 業績欄の「'」表記を統一

## チェック項目

- [ ] Dev環境で動作確認をした
- [ ] 複雑なコードにはコメントを記載してある

## コメント
